### PR TITLE
Hardcoded strings moved to resources

### DIFF
--- a/wcf_chat/ServiceChat.cs
+++ b/wcf_chat/ServiceChat.cs
@@ -15,17 +15,21 @@ namespace wcf_chat
         List<ServerUser> users = new List<ServerUser>();
         int nextId = 1;
 
+        public static class Messages
+        {
+            public const string UserConnected = "{0} підключився до чату!";
+            public const string UserDisconnected = "{0} покинув чат!";
+        }
+
         public int Connect(string name)
         {
-
             ServerUser user = new ServerUser() {
                 ID = nextId,
                 Name = name,
                 operationContext = OperationContext.Current
             };
             nextId++;
-
-            SendMsg(": " + user.Name + " підключився до чату!",0);
+            SendMsg(string.Format(Messages.UserConnected, user.Name), 0);
             users.Add(user);  
             return user.ID;
         }
@@ -36,7 +40,7 @@ namespace wcf_chat
             if (user!=null)
             {
                 users.Remove(user);
-                SendMsg(": " + user.Name + " покинув чат!",0);
+                SendMsg(string.Format(Messages.UserDisconnected, user.Name), 0);
             }
         }
 


### PR DESCRIPTION
#5 - Issue

## What has been changed/added in the code?


Key changes:
- Using `string.Format` to insert the user's name into message templates.
- Replacing hardcoded strings with easily manageable constants in the form of text templates.

## Description
1. Hardcoded message strings (e.g., "joined the chat", "left the chat") have been moved to constants.
2. A static Messages class has been created to store all message templates.
3. This improves localization support and future text maintenance.

## Why this change is necessary:
**1. Improved Code Maintainability**
- Hardcoded strings make modifications difficult - for example, changing a message text or adding a new language requires manual code changes.

**2. Preparation for Localization**
- Extracting strings into resources (e.g., the `Messages` class) allows for easy adaptation to a multilingual environment without modifying the core code.

**3. Reduced Code Duplication**
- If the same string is used in multiple places, updating it in one location (`Messages` class) will automatically apply the change everywhere.

**4. Improved Code Readability**
- Replacing strings with meaningful constants, such as `Messages.UserConnected` or `Messages.UserDisconnected`, makes the code more readable and understandable.

**This change makes the code more structured, scalable, and easier to modify in the future.**